### PR TITLE
MAC address, register, power on, delete

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -22,9 +22,32 @@ main() {
   local fullbasepath=$(readlink -f "$INFOLDER")/
   cd "$OUTFOLDER"/
   sed -i '/sched.swap.derivedName/d' ./*.vmx #delete swap file line, will be auto recreated
-  sed -i -e '/displayName =/ s/= .*/= "Server Clone"/' ./*.vmx #Change display name config value
+  sed -i -e '/displayName =/ s/= .*/= "'$OUTFOLDER'"/' ./*.vmx #Change display name config value
   local escapedpath=$(echo "$fullbasepath" | sed -e 's/[\/&]/\\&/g')
   sed -i -e '/parentFileNameHint=/ s/="/="'"$escapedpath"'/' ./*-000001.vmdk #change parent disk path
+
+  # Forces generation of new MAC + DHCP, I think.
+  sed -i '/ethernet0.generatedAddress/d' ./*.vmx
+  sed -i '/ethernet0.addressType/d' ./*.vmx
+
+  # Forces creation of a fresh UUID for the VM.  Obviates the need for the line
+  # commented out below:
+  #echo 'answer.msg.uuid.altered="I copied it" ' >>./*.vmx
+  sed -i '/uuid.location/d' ./*.vmx
+  sed -i '/uuid.bios/d' ./*.vmx
+
+  # Things that ghetto-esxi-linked-clones.sh did that we might want.  I can only guess at their use/value.
+  #sed -i '/scsi0:0.fileName/d' ${STORAGE_PATH}/$FINAL_VM_NAME/$FINAL_VM_NAME.vmx
+  #echo "scsi0:0.fileName = \"${STORAGE_PATH}/${GOLDEN_VM_NAME}/${VMDK_PATH}\"" >> ${STORAGE_PATH}/$FINAL_VM_NAME/$FINAL_VM_NAME.vmx
+  #sed -i 's/nvram = "'${GOLDEN_VM_NAME}.nvram'"/nvram = "'${FINAL_VM_NAME}.nvram'"/' ${STORAGE_PATH}/$FINAL_VM_NAME/$FINAL_VM_NAME.vmx
+  #sed -i 's/extendedConfigFile = "'${GOLDEN_VM_NAME}.vmxf'"/extendedConfigFile = "'${FINAL_VM_NAME}.vmxf'"/' ${STORAGE_PATH}/$FINAL_VM_NAME/$FINAL_VM_NAME.vmx
+
+  # Register the machine so that it appears in vSphere.
+  FULL_PATH=`pwd`/*.vmx
+  VMID=`vim-cmd solo/registervm $FULL_PATH`
+
+  # Power on the machine.
+  vim-cmd vmsvc/power.on $VMID
 }
 
 main

--- a/deleteclone.sh
+++ b/deleteclone.sh
@@ -1,0 +1,12 @@
+# Deletes a cloned VM created by clone.sh.
+if [ $# -le 0 ]
+then
+  echo "USAGE: ./deleteclone.sh vm_name"
+  exit 1
+fi
+readonly VMNAME=$1
+
+VMID=$(vim-cmd vmsvc/getallvms | awk "/^[0-9]+ +$VMNAME /{print \$1}")
+vim-cmd vmsvc/power.off $VMID
+vim-cmd vmsvc/unregister $VMID
+rm -rf $VMNAME


### PR DESCRIPTION
Reset uuid so VMware does not question whether this is a copied or moved
machine.  Reset ethernet so that a new MAC address is generated.
Automatically register the machine and power it on.  deleteclone.sh
powers off, unregisters and deletes a machine.
