### PR TITLE
linked clone get incorrect vmdk fix

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -17,7 +17,7 @@ main() {
     exit 1
   fi
   
-  VMFILE=`ls $INFOLDER | grep -o "[0-9]\{6,6\}" | sort -u | tail -1`
+  VMFILE=`grep scsi0\:0\.fileName "$INFOLDER"/*.vmx | grep -o "[0-9]\{6,6\}"`
 
   makeandcopy
 


### PR DESCRIPTION
get vmdk from vmx rather than get the maximum number of vmdk in folder